### PR TITLE
Module inits use MODULE_NAME

### DIFF
--- a/ddlitlab2024/dataset/__init__.py
+++ b/ddlitlab2024/dataset/__init__.py
@@ -3,6 +3,8 @@ import os
 
 from ddlitlab2024 import LOGGING_PATH, SESSION_ID
 
+MODULE_NAME: str = "dataset"
+
 # Init logging
 logging.basicConfig(
     filename=LOGGING_PATH,
@@ -16,5 +18,5 @@ console = logging.StreamHandler()
 console.setLevel(os.environ.get("LOGLEVEL", "INFO"))
 console.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 
-logger = logging.getLogger("dataset")
+logger = logging.getLogger(MODULE_NAME)
 logger.addHandler(console)

--- a/ddlitlab2024/ml/__init__.py
+++ b/ddlitlab2024/ml/__init__.py
@@ -3,6 +3,8 @@ import os
 
 from ddlitlab2024 import LOGGING_PATH, SESSION_ID
 
+MODULE_NAME: str = "ml"
+
 # Init logging
 logging.basicConfig(
     filename=LOGGING_PATH,
@@ -16,5 +18,5 @@ console = logging.StreamHandler()
 console.setLevel(os.environ.get("LOGLEVEL", "INFO"))
 console.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 
-logger = logging.getLogger("ml")
+logger = logging.getLogger(MODULE_NAME)
 logger.addHandler(console)


### PR DESCRIPTION
# Summary
Create `MODULE_NAME` in module's `__init__.py` files to make it more obvious, this should be changed for each module