### PR TITLE
DB Model: change Rotation from roll,pitch to quaternion

### DIFF
--- a/ddlitlab2024/dataset/models.py
+++ b/ddlitlab2024/dataset/models.py
@@ -94,15 +94,19 @@ class Rotation(Base):
     _id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     stamp: Mapped[float] = mapped_column(Float, nullable=False)
     recording_id: Mapped[int] = mapped_column(Integer, ForeignKey("Recording._id"), nullable=False)
-    roll: Mapped[float] = mapped_column(Float, nullable=False)
-    pitch: Mapped[float] = mapped_column(Float, nullable=False)
+    x: Mapped[float] = mapped_column(Float, nullable=False)
+    y: Mapped[float] = mapped_column(Float, nullable=False)
+    z: Mapped[float] = mapped_column(Float, nullable=False)
+    w: Mapped[float] = mapped_column(Float, nullable=False)
 
     recording: Mapped["Recording"] = relationship("Recording", back_populates="rotations")
 
     __table_args__ = (
         CheckConstraint("stamp >= 0"),
-        CheckConstraint("roll >= 0 AND roll < 2 * pi()"),
-        CheckConstraint("pitch >= 0 AND pitch < 2 * pi()"),
+        CheckConstraint("x >= -1 AND x <= 1"),
+        CheckConstraint("y >= -1 AND y <= 1"),
+        CheckConstraint("z >= -1 AND z <= 1"),
+        CheckConstraint("w >= -1 AND w <= 1"),
     )
 
 


### PR DESCRIPTION
This pull request updates the database model to change the Rotation field from storing roll and pitch angles to using quaternion values. By switching to quaternion representation, it enhances the accuracy and stability of rotation calculations in the system. Adjustments have been made both in the database model for storing quaternion values and in the associated code to handle quaternion rotation data effectively. Your feedback on these changes is appreciated.