### PR TITLE
CLI: move back to argparse

### DIFF
--- a/ddlitlab2024/__init__.py
+++ b/ddlitlab2024/__init__.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import os
 import sys
+from pathlib import Path
 from uuid import UUID, uuid4
 
 _project_name: str = "ddlitlab2024"
@@ -39,4 +40,4 @@ LOGGING_PATH: str = _logging_path
 
 SESSION_ID: UUID = uuid4()
 
-DB_PATH: str = os.path.join(os.path.dirname(__file__), "dataset", "db.sqlite3")
+DB_PATH: Path = Path.joinpath(Path(__file__).parent, "dataset", "db.sqlite3")

--- a/ddlitlab2024/dataset/db.py
+++ b/ddlitlab2024/dataset/db.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -6,7 +8,7 @@ from ddlitlab2024.dataset.models import Base
 
 
 class Database:
-    def __init__(self, db_path: str):
+    def __init__(self, db_path: Path):
         self.db_path = db_path
         self.engine: Engine = self._setup_sqlite()
         self.session: Session | None = None


### PR DESCRIPTION
This pull request includes several changes to improve the `ddlitlab2024` project. The most significant updates involve replacing the `Tap` library with `argparse` for command-line argument parsing, updating the database path handling to use `pathlib.Path`, and refactoring the main function to support new subcommands.

### Command-line argument parsing improvements:
* Replaced `Tap` with `argparse` for more flexible and standard command-line argument parsing in `ddlitlab2024/dataset/cli.py`. [[1]](diffhunk://#diff-08e6625f1957fd33ab6f876a12490b491ce13d09085f5e47435d937183bb4d09L1-L6) [[2]](diffhunk://#diff-08e6625f1957fd33ab6f876a12490b491ce13d09085f5e47435d937183bb4d09L19-R39)

### Database path handling:
* Changed the database path handling from `os.path` to `pathlib.Path` in `ddlitlab2024/__init__.py` and `ddlitlab2024/dataset/db.py`. [[1]](diffhunk://#diff-f5be400a05293e145b792af4d60097b5003994027f6883e9b17b8559303b0d43L42-R43) [[2]](diffhunk://#diff-f41e94a30cc45428f30030b1c60e65d7f8a9ce7d7cac49be950bc2ffb2af1d20L9-R11)

### Main function refactoring:
* Updated the `main` function in `ddlitlab2024/dataset/main.py` to handle new subcommands and improve session management.

### Additional imports:
* Added necessary imports in various files to support the new changes. [[1]](diffhunk://#diff-f5be400a05293e145b792af4d60097b5003994027f6883e9b17b8559303b0d43R4) [[2]](diffhunk://#diff-f41e94a30cc45428f30030b1c60e65d7f8a9ce7d7cac49be950bc2ffb2af1d20R1-R2) [[3]](diffhunk://#diff-781181ae963f79b6d77ef42254b4338bf9b981d98c38de1cd330015df421b44dR3-R18)