### PR TITLE
Create recording2mcap and dummy_data tools

### DIFF
--- a/.github/workflows/dummy_db.yml
+++ b/.github/workflows/dummy_db.yml
@@ -1,4 +1,4 @@
-name: Test Database Creation
+name: Create DB with dummy data
 
 on:
   push:
@@ -29,5 +29,8 @@ jobs:
     - name: Install dependencies
       run: poetry install
 
-    - name: Run create-db
+    - name: Create DB schema
       run: poetry run cli db create_schema
+
+    - name: Populate DB with dummy data
+      run: poetry run cli db dummy-data -n 2

--- a/.github/workflows/dummy_db.yml
+++ b/.github/workflows/dummy_db.yml
@@ -30,7 +30,7 @@ jobs:
       run: poetry install
 
     - name: Create DB schema
-      run: poetry run cli db create_schema
+      run: poetry run cli db create-schema
 
     - name: Populate DB with dummy data
       run: poetry run cli db dummy-data -n 2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ logs/
 *.csv
 *.sqlite
 *.sqlite3
+*.mcap
+*/metadata.yaml
 
 # Created by .ignore support plugin (hsz.mobi)
 ### JetBrains template

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,12 @@
 {
     "cSpell.words": [
+        "bigendian",
         "ddlitlab",
+        "mcap",
+        "nanosec",
         "nullable",
+        "rclpy",
+        "rosbag",
         "sessionmaker",
         "sqlalchemy",
         "sqlite"

--- a/ddlitlab2024/dataset/cli.py
+++ b/ddlitlab2024/dataset/cli.py
@@ -29,11 +29,17 @@ class CLIArgs:
         db_subcommand_parser = db_parser.add_subparsers(dest="db_command", help="Database command")
 
         db_subcommand_parser.add_parser("create-schema", help="Create the base database schema, if it doesn't exist.")
+
+        dummy_data_subparser = db_subcommand_parser.add_parser("dummy-data", help="Insert dummy data into the database")
+        dummy_data_subparser.add_argument(
+            "-n", "--num_recordings", type=int, default=10, help="Number of recordings to insert"
+        )
+
         recording2mcap_subparser = db_subcommand_parser.add_parser(
             "recording2mcap", help="Convert a recording to an mcap file"
         )
         recording2mcap_subparser.add_argument("recording", type=str, help="Recording to convert")
-        recording2mcap_subparser.add_argument("output", type=Path, help="MCAP output file to write to")
+        recording2mcap_subparser.add_argument("output_dir", type=Path, help="Output directory to write to")
 
     def parse_args(self) -> argparse.Namespace:
         return self.parser.parse_args()

--- a/ddlitlab2024/dataset/cli.py
+++ b/ddlitlab2024/dataset/cli.py
@@ -23,7 +23,7 @@ class CLIArgs:
         self.parser.add_argument("--version", action="store_true", help="Print version and exit")
 
         subparsers = self.parser.add_subparsers(dest="command", help="Command to run")
-        import_parser = subparsers.add_parser(CLICommand.IMPORT.value, help="Import data into the database")
+        # import_parser = subparsers.add_parser(CLICommand.IMPORT.value, help="Import data into the database")
 
         db_parser = subparsers.add_parser(CLICommand.DB.value, help="Database management commands")
         db_subcommand_parser = db_parser.add_subparsers(dest="db_command", help="Database command")

--- a/ddlitlab2024/dataset/dummy_data.py
+++ b/ddlitlab2024/dataset/dummy_data.py
@@ -1,0 +1,161 @@
+import datetime
+import math
+import random
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from ddlitlab2024.dataset import logger
+from ddlitlab2024.dataset.models import (
+    GameState,
+    Image,
+    JointCommand,
+    JointState,
+    Recording,
+    RobotState,
+    Rotation,
+    TeamColor,
+)
+
+
+def insert_recordings(db: Session, n) -> list[int]:
+    logger.debug("Inserting recordings...")
+    for i in range(n):
+        db.add(
+            Recording(
+                allow_public=True,
+                original_file=f"dummy_original_file{i}",
+                team_name=f"dummy_team_name{i}",
+                team_color=random.choice(list(TeamColor)),
+                robot_type=f"dummy_robot_type{i}",
+                start_time=datetime.datetime.now(),
+                location=f"dummy_location{i}",
+                simulated=True,
+                img_width_scaling=1.0,
+                img_height_scaling=1.0,
+            ),
+        )
+    db.flush()  # Ensure the recording is written to the database and the ID is generated
+    recording = db.query(Recording).order_by(Recording._id.desc()).limit(n).all()
+    if recording is None:
+        raise ValueError("Failed to insert recordings")
+    return [r._id for r in reversed(recording)]
+
+
+def insert_images(db: Session, recording_ids: list[int], n: int) -> None:
+    for recording_id in recording_ids:
+        # Get width and height from the recording
+        recording = db.query(Recording).get(recording_id)
+        if recording is None:
+            raise ValueError(f"Recording '{recording_id}' not found")
+        for i in range(n):
+            db.add(
+                Image(
+                    stamp=float(i),
+                    recording_id=recording_id,
+                    data=np.random.randint(
+                        0, 255, (recording.img_height, recording.img_width, 3), dtype=np.uint8
+                    ).tobytes(),
+                )
+            )
+
+
+def insert_rotations(db: Session, recording_ids: list[int], n: int) -> None:
+    for recording_id in recording_ids:
+        for i in range(n):
+            db.add(
+                Rotation(
+                    stamp=float(i),
+                    recording_id=recording_id,
+                    x=random.random(),
+                    y=random.random(),
+                    z=random.random(),
+                    w=random.random(),
+                ),
+            )
+
+
+def insert_joint_states(db: Session, recording_ids: list[int], n: int) -> None:
+    for recording_id in recording_ids:
+        for i in range(n):
+            db.add(
+                JointState(
+                    stamp=float(i),
+                    recording_id=recording_id,
+                    r_shoulder_pitch=random.random() * 2 * math.pi,
+                    l_shoulder_pitch=random.random() * 2 * math.pi,
+                    r_shoulder_roll=random.random() * 2 * math.pi,
+                    l_shoulder_roll=random.random() * 2 * math.pi,
+                    r_elbow=random.random() * 2 * math.pi,
+                    l_elbow=random.random() * 2 * math.pi,
+                    r_hip_yaw=random.random() * 2 * math.pi,
+                    l_hip_yaw=random.random() * 2 * math.pi,
+                    r_hip_roll=random.random() * 2 * math.pi,
+                    l_hip_roll=random.random() * 2 * math.pi,
+                    r_hip_pitch=random.random() * 2 * math.pi,
+                    l_hip_pitch=random.random() * 2 * math.pi,
+                    r_knee=random.random() * 2 * math.pi,
+                    l_knee=random.random() * 2 * math.pi,
+                    r_ankle_pitch=random.random() * 2 * math.pi,
+                    l_ankle_pitch=random.random() * 2 * math.pi,
+                    r_ankle_roll=random.random() * 2 * math.pi,
+                    l_ankle_roll=random.random() * 2 * math.pi,
+                    head_pan=random.random() * 2 * math.pi,
+                    head_tilt=random.random() * 2 * math.pi,
+                ),
+            )
+
+
+def insert_joint_commands(db: Session, recording_ids: list[int], n: int) -> None:
+    for recording_id in recording_ids:
+        for i in range(n):
+            db.add(
+                JointCommand(
+                    stamp=float(i),
+                    recording_id=recording_id,
+                    r_shoulder_pitch=random.random() * 2 * math.pi,
+                    l_shoulder_pitch=random.random() * 2 * math.pi,
+                    r_shoulder_roll=random.random() * 2 * math.pi,
+                    l_shoulder_roll=random.random() * 2 * math.pi,
+                    r_elbow=random.random() * 2 * math.pi,
+                    l_elbow=random.random() * 2 * math.pi,
+                    r_hip_yaw=random.random() * 2 * math.pi,
+                    l_hip_yaw=random.random() * 2 * math.pi,
+                    r_hip_roll=random.random() * 2 * math.pi,
+                    l_hip_roll=random.random() * 2 * math.pi,
+                    r_hip_pitch=random.random() * 2 * math.pi,
+                    l_hip_pitch=random.random() * 2 * math.pi,
+                    r_knee=random.random() * 2 * math.pi,
+                    l_knee=random.random() * 2 * math.pi,
+                    r_ankle_pitch=random.random() * 2 * math.pi,
+                    l_ankle_pitch=random.random() * 2 * math.pi,
+                    r_ankle_roll=random.random() * 2 * math.pi,
+                    l_ankle_roll=random.random() * 2 * math.pi,
+                    head_pan=random.random() * 2 * math.pi,
+                    head_tilt=random.random() * 2 * math.pi,
+                ),
+            )
+
+
+def insert_game_states(db: Session, recording_ids: list[int], n: int) -> None:
+    for recording_id in recording_ids:
+        for i in range(n):
+            db.add(
+                GameState(
+                    stamp=float(i),
+                    recording_id=recording_id,
+                    state=random.choice(list(RobotState)),
+                ),
+            )
+
+
+def insert_dummy_data(db: Session, n: int = 10) -> None:
+    logger.info("Inserting dummy data...")
+    recording_ids: list[int] = insert_recordings(db, n)
+    insert_images(db, recording_ids, n)
+    insert_rotations(db, recording_ids, n)
+    insert_joint_states(db, recording_ids, n)
+    insert_joint_commands(db, recording_ids, n)
+    insert_game_states(db, recording_ids, n)
+    db.commit()
+    logger.info(f"Dummy data inserted. Recording IDs: {recording_ids}")

--- a/ddlitlab2024/dataset/lichtblick_layout.json
+++ b/ddlitlab2024/dataset/lichtblick_layout.json
@@ -1,0 +1,180 @@
+{
+  "configById": {
+    "3D!18i6zy7": {
+      "layers": {
+        "845139cb-26bc-40b3-8161-8ab60af4baf5": {
+          "visible": true,
+          "frameLocked": true,
+          "label": "Grid",
+          "instanceId": "845139cb-26bc-40b3-8161-8ab60af4baf5",
+          "layerId": "foxglove.Grid",
+          "size": 10,
+          "divisions": 10,
+          "lineWidth": 1,
+          "color": "#248eff",
+          "position": [
+            0,
+            0,
+            0
+          ],
+          "rotation": [
+            0,
+            0,
+            0
+          ],
+          "order": 1
+        }
+      },
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 45,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "imageMode": {}
+    },
+    "Image!3mnp456": {
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 45,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {},
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "imageMode": {}
+    },
+    "RawMessages!os6rgs": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "diffTopicPath": "",
+      "showFullMessageForDiff": false,
+      "topicPath": "/rotation"
+    },
+    "RawMessages!d5ldb1": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "diffTopicPath": "",
+      "showFullMessageForDiff": false,
+      "topicPath": "/game_state"
+    },
+    "StateTransitions!s5d70t": {
+      "paths": [
+        {
+          "value": "/game_state.data",
+          "timestampMethod": "receiveTime"
+        }
+      ],
+      "isSynced": true
+    },
+    "RawMessages!2phnd5h": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "diffTopicPath": "",
+      "showFullMessageForDiff": false,
+      "topicPath": "/joint_states"
+    },
+    "RawMessages!16fkjz7": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "diffTopicPath": "",
+      "showFullMessageForDiff": false,
+      "topicPath": "/joint_commands"
+    }
+  },
+  "globalVariables": {},
+  "userNodes": {},
+  "playbackConfig": {
+    "speed": 1
+  },
+  "layout": {
+    "first": "3D!18i6zy7",
+    "second": {
+      "first": "Image!3mnp456",
+      "second": {
+        "first": {
+          "first": "RawMessages!os6rgs",
+          "second": {
+            "direction": "column",
+            "second": "StateTransitions!s5d70t",
+            "first": "RawMessages!d5ldb1"
+          },
+          "direction": "row"
+        },
+        "second": {
+          "first": "RawMessages!2phnd5h",
+          "second": "RawMessages!16fkjz7",
+          "direction": "row"
+        },
+        "direction": "column"
+      },
+      "direction": "column",
+      "splitPercentage": 30
+    },
+    "direction": "row",
+    "splitPercentage": 52.76988636363637
+  }
+}

--- a/ddlitlab2024/dataset/main.py
+++ b/ddlitlab2024/dataset/main.py
@@ -15,7 +15,6 @@ from ddlitlab2024 import __version__
 from ddlitlab2024.dataset import logger
 from ddlitlab2024.dataset.cli import CLIArgs, CLICommand
 from ddlitlab2024.dataset.db import Database
-from ddlitlab2024.dataset.recording2mcap import recording2mcap
 
 err_console = Console(stderr=True)
 
@@ -26,19 +25,28 @@ def main():
     try:
         logger.debug("Parsing CLI args...")
         args: Namespace = CLIArgs().parse_args()
+        logger.debug(f"CLI args: {args}")
+
         if args.version:
             logger.info(f"running ddlitlab2024 CLI v{__version__}")
             sys.exit(0)
 
         if args.command == CLICommand.DB:
-            create_schema = args.db_command == "create-schema"
+            create_schema = args.db_command == "create-schema" or args.db_command == "dummy-data"
             db: Session = Database(args.db_path).create_session(create_schema=create_schema)
-            logger.info(f"Database session created: {db}")
+            logger.debug("Database session created")
 
-            if args.db_command == "recording2mcap":
-                recording2mcap(db, args.recording, args.output)
+            match args.db_command:
+                case "recording2mcap":
+                    from ddlitlab2024.dataset.recording2mcap import recording2mcap
 
-        logger.info(f"CLI args: {args}")
+                    recording2mcap(db, args.recording, args.output_dir)
+
+                case "dummy-data":
+                    from ddlitlab2024.dataset.dummy_data import insert_dummy_data
+
+                    insert_dummy_data(db, args.num_recordings)
+
         sys.exit(0)
     except Exception as e:
         logger.error(e)

--- a/ddlitlab2024/dataset/models.py
+++ b/ddlitlab2024/dataset/models.py
@@ -229,3 +229,9 @@ class GameState(Base):
     recording: Mapped["Recording"] = relationship("Recording", back_populates="game_states")
 
     __table_args__ = (CheckConstraint(state.in_(RobotState.values())),)
+
+
+def stamp_to_seconds_nanoseconds(stamp: float) -> tuple[int, int]:
+    seconds = int(stamp // 1)
+    nanoseconds = int((stamp % 1) * 1e9)
+    return seconds, nanoseconds

--- a/ddlitlab2024/dataset/models.py
+++ b/ddlitlab2024/dataset/models.py
@@ -235,3 +235,7 @@ def stamp_to_seconds_nanoseconds(stamp: float) -> tuple[int, int]:
     seconds = int(stamp // 1)
     nanoseconds = int((stamp % 1) * 1e9)
     return seconds, nanoseconds
+
+
+def stamp_to_nanoseconds(stamp: float) -> int:
+    return int(stamp * 1e9)

--- a/ddlitlab2024/dataset/reader.py
+++ b/ddlitlab2024/dataset/reader.py
@@ -1,8 +1,0 @@
-import sqlite3
-
-from ddlitlab2024 import DB_PATH
-
-
-def get_connection(path: str = DB_PATH) -> sqlite3.Connection:
-    conn = sqlite3.connect(path)
-    return conn

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -101,7 +101,7 @@ def write_rotations(
 
     # Write rotations
     logger.info("Writing rotations")
-    for i, rotation in enumerate(recording.rotations):
+    for rotation in recording.rotations:
         rotation_msg = Quaternion(
             x=rotation.x,
             y=rotation.y,

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -1,0 +1,253 @@
+import shutil
+from pathlib import Path
+
+import rosbag2_py
+from builtin_interfaces.msg import Time
+from geometry_msgs.msg import Quaternion
+from rclpy.serialization import serialize_message
+from sensor_msgs.msg import Image, JointState
+from sqlalchemy.orm import Session
+from std_msgs.msg import Header, String
+
+from ddlitlab2024.dataset import logger
+from ddlitlab2024.dataset.models import Recording, stamp_to_seconds_nanoseconds
+
+
+def get_recording(db: Session, recording_id_or_filename: str | int) -> Recording:
+    """Get the recording from the input string or integer
+
+    param db: The database
+    param recording_id_or_filename: The recording ID or original filename
+    raises ValueError: If the recording does not exist
+    return: The recording
+    """
+    if isinstance(recording_id_or_filename, int) or recording_id_or_filename.isdigit():
+        # Verify that the recording exists
+        recording_id = int(recording_id_or_filename)
+        recording = db.query(Recording).get(recording_id)
+        if recording is None:
+            raise ValueError(f"Recording '{recording_id}' not found")
+        return recording
+    elif isinstance(recording_id_or_filename, str):
+        recording = db.query(Recording).filter(Recording.original_file == recording_id_or_filename).first()
+        if recording is None:
+            raise ValueError(f"Recording with original filename '{recording_id_or_filename}' not found")
+        return recording
+    else:
+        raise TypeError("Recording ID must be an integer or string")
+
+
+def get_writer(output: Path) -> rosbag2_py.SequentialWriter:
+    """Get the mcap writer.
+
+    param output: The output mcap file
+    return: The mcap writer
+    """
+    if output.exists():
+        # Remove the existing directory
+        shutil.rmtree(output)
+
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(output), storage_id="mcap"),
+        rosbag2_py.ConverterOptions(
+            input_serialization_format="cdr",
+            output_serialization_format="cdr",
+        ),
+    )
+    return writer
+
+
+def write_images(recording: Recording, writer: rosbag2_py.SequentialWriter) -> None:
+    """Write the images to the mcap file
+
+    param recording: The recording
+    param writer: The mcap writer
+    """
+    # Create topic
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(name="/image", type="sensor_msgs/msg/Image", serialization_format="cdr")
+    )
+
+    # Write images
+    logger.info("Writing images")
+    for image in recording.images:
+        seconds, nanoseconds = stamp_to_seconds_nanoseconds(image.stamp)
+        image_msg = Image(
+            header=Header(stamp=Time(sec=seconds, nanosec=nanoseconds), frame_id="camera_optical"),
+            height=recording.img_height,
+            width=recording.img_width,
+            encoding="rgb8",
+            is_bigendian=0,
+            step=recording.img_width * 3,
+            data=image.data,
+        )
+        writer.write("/image", serialize_message(image_msg), int(image.stamp * 1_000_000_000))
+
+
+def write_rotations(
+    recording: Recording,
+    writer: rosbag2_py.SequentialWriter,
+) -> None:
+    """Write the rotations to the mcap file
+
+    param recording: The recording
+    param writer: The mcap writer
+    """
+    # Create topic
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(name="/rotation", type="geometry_msgs/msg/Quaternion", serialization_format="cdr")
+    )
+
+    # Write rotations
+    logger.info("Writing rotations")
+    for i, rotation in enumerate(recording.rotations):
+        rotation_msg = Quaternion(
+            x=rotation.x,
+            y=rotation.y,
+            z=rotation.z,
+            w=rotation.w,
+        )
+        writer.write("/rotation", serialize_message(rotation_msg), int(rotation.stamp * 1_000_000_000))
+
+
+def write_joint_states(
+    recording: Recording,
+    writer: rosbag2_py.SequentialWriter,
+) -> None:
+    """Write the joint states to the mcap file
+
+    param recording: The recording
+    param writer: The mcap writer
+    """
+    # Create topic
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(name="/joint_states", type="sensor_msgs/msg/JointState", serialization_format="cdr")
+    )
+
+    # Write joint states
+    logger.info("Writing joint states")
+    for joint_state in recording.joint_states:
+        seconds, nanoseconds = stamp_to_seconds_nanoseconds(joint_state.stamp)
+        joints: list[tuple[str, float]] = [
+            ("r_shoulder_pitch", joint_state.r_shoulder_pitch),
+            ("l_shoulder_pitch", joint_state.l_shoulder_pitch),
+            ("r_shoulder_roll", joint_state.r_shoulder_roll),
+            ("l_shoulder_roll", joint_state.l_shoulder_roll),
+            ("r_elbow", joint_state.r_elbow),
+            ("l_elbow", joint_state.l_elbow),
+            ("r_hip_yaw", joint_state.r_hip_yaw),
+            ("l_hip_yaw", joint_state.l_hip_yaw),
+            ("r_hip_roll", joint_state.r_hip_roll),
+            ("l_hip_roll", joint_state.l_hip_roll),
+            ("r_hip_pitch", joint_state.r_hip_pitch),
+            ("l_hip_pitch", joint_state.l_hip_pitch),
+            ("r_knee", joint_state.r_knee),
+            ("l_knee", joint_state.l_knee),
+            ("r_ankle_pitch", joint_state.r_ankle_pitch),
+            ("l_ankle_pitch", joint_state.l_ankle_pitch),
+            ("r_ankle_roll", joint_state.r_ankle_roll),
+            ("l_ankle_roll", joint_state.l_ankle_roll),
+            ("head_pan", joint_state.head_pan),
+            ("head_tilt", joint_state.head_tilt),
+        ]
+        joint_state_msg = JointState(
+            header=Header(stamp=Time(sec=seconds, nanosec=nanoseconds), frame_id="base_link"),
+            name=[name for name, _ in joints],
+            position=[position for _, position in joints],
+            velocity=[0.0] * len(joints),
+            effort=[0.0] * len(joints),
+        )
+        writer.write("/joint_states", serialize_message(joint_state_msg), int(joint_state.stamp * 1_000_000_000))
+
+
+def write_joint_commands(
+    recording: Recording,
+    writer: rosbag2_py.SequentialWriter,
+) -> None:
+    """Write the joint commands to the mcap file
+
+    param recording: The recording
+    param writer: The mcap writer
+    """
+    # Create topic
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(name="/joint_commands", type="sensor_msgs/msg/JointState", serialization_format="cdr")
+    )
+
+    # Write joint commands
+    logger.info("Writing joint commands")
+    for joint_command in recording.joint_commands:
+        seconds, nanoseconds = stamp_to_seconds_nanoseconds(joint_command.stamp)
+        joints: list[tuple[str, float]] = [
+            ("r_shoulder_pitch", joint_command.r_shoulder_pitch),
+            ("l_shoulder_pitch", joint_command.l_shoulder_pitch),
+            ("r_shoulder_roll", joint_command.r_shoulder_roll),
+            ("l_shoulder_roll", joint_command.l_shoulder_roll),
+            ("r_elbow", joint_command.r_elbow),
+            ("l_elbow", joint_command.l_elbow),
+            ("r_hip_yaw", joint_command.r_hip_yaw),
+            ("l_hip_yaw", joint_command.l_hip_yaw),
+            ("r_hip_roll", joint_command.r_hip_roll),
+            ("l_hip_roll", joint_command.l_hip_roll),
+            ("r_hip_pitch", joint_command.r_hip_pitch),
+            ("l_hip_pitch", joint_command.l_hip_pitch),
+            ("r_knee", joint_command.r_knee),
+            ("l_knee", joint_command.l_knee),
+            ("r_ankle_pitch", joint_command.r_ankle_pitch),
+            ("l_ankle_pitch", joint_command.l_ankle_pitch),
+            ("r_ankle_roll", joint_command.r_ankle_roll),
+            ("l_ankle_roll", joint_command.l_ankle_roll),
+            ("head_pan", joint_command.head_pan),
+            ("head_tilt", joint_command.head_tilt),
+        ]
+        joint_command_msg = JointState(
+            header=Header(stamp=Time(sec=seconds, nanosec=nanoseconds), frame_id="base_link"),
+            name=[name for name, _ in joints],
+            position=[position for _, position in joints],
+            velocity=[0.0] * len(joints),
+            effort=[0.0] * len(joints),
+        )
+        writer.write("/joint_commands", serialize_message(joint_command_msg), int(joint_command.stamp * 1_000_000_000))
+
+
+def write_game_states(
+    recording: Recording,
+    writer: rosbag2_py.SequentialWriter,
+) -> None:
+    """Write the game states to the mcap file
+
+    param recording: The recording
+    param writer: The mcap writer
+    """
+    # Create topic
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(name="/game_state", type="std_msgs/msg/String", serialization_format="cdr")
+    )
+
+    # Write game states
+    logger.info("Writing game states")
+    for game_state in recording.game_states:
+        game_state_msg = String(data=game_state.state)
+        writer.write("/game_state", serialize_message(game_state_msg), int(game_state.stamp * 1_000_000_000))
+
+
+def recording2mcap(db: Session, recording_id_or_filename: str | int, output: Path) -> None:
+    """Convert a recording to an mcap file
+
+    param db: The database
+    param recording_id_or_filename: The recording ID or original filename
+    param output: The output mcap file
+    """
+    recording = get_recording(db, recording_id_or_filename)
+    logger.info(f"Converting recording '{recording._id}' to mcap file '{output}'")
+
+    writer = get_writer(output)
+    write_images(recording, writer)
+    write_rotations(recording, writer)
+    write_joint_states(recording, writer)
+    write_joint_commands(recording, writer)
+    write_game_states(recording, writer)
+    del writer
+
+    logger.info(f"Recording '{recording._id}' converted to mcap file '{output}'")

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -53,6 +53,10 @@ def get_writer(output: Path) -> rosbag2_py.SequentialWriter:
     return: The mcap writer
     """
     if output.exists():
+        # Ask the user if they want to overwrite the existing file
+        if not input(f"Output directory '{output}' already exists. Overwrite? (y/n): ").lower().startswith("y"):
+            logger.info("Exiting")
+            sys.exit(0)
         # Remove the existing directory
         shutil.rmtree(output)
 

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -1,16 +1,25 @@
 import shutil
+import sys
 from pathlib import Path
 
-import rosbag2_py
-from builtin_interfaces.msg import Time
-from geometry_msgs.msg import Quaternion
-from rclpy.serialization import serialize_message
-from sensor_msgs.msg import Image, JointState
 from sqlalchemy.orm import Session
-from std_msgs.msg import Header, String
 
 from ddlitlab2024.dataset import logger
 from ddlitlab2024.dataset.models import Recording, stamp_to_seconds_nanoseconds
+
+try:
+    import rosbag2_py
+    from builtin_interfaces.msg import Time
+    from geometry_msgs.msg import Quaternion
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Image, JointState
+    from std_msgs.msg import Header, String
+except ImportError:
+    logger.error(
+        "Failed to import ROS 2 packages. These are necessary to convert recordings to .mcap files. "
+        "Make sure ROS 2 installed and sourced."
+    )
+    sys.exit(1)
 
 
 def get_recording(db: Session, recording_id_or_filename: str | int) -> Recording:

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -47,23 +47,23 @@ def get_recording(db: Session, recording_id_or_filename: str | int) -> Recording
         raise TypeError("Recording ID must be an integer or string")
 
 
-def get_writer(output: Path) -> rosbag2_py.SequentialWriter:
+def get_writer(output_dir: Path) -> rosbag2_py.SequentialWriter:
     """Get the mcap writer.
 
-    param output: The output mcap file
+    param output_dir: The output directory
     return: The mcap writer
     """
-    if output.exists():
+    if output_dir.exists():
         # Ask the user if they want to overwrite the existing file
-        if not input(f"Output directory '{output}' already exists. Overwrite? (y/n): ").lower().startswith("y"):
+        if not input(f"Output directory '{output_dir}' already exists. Overwrite? (y/n): ").lower().startswith("y"):
             logger.info("Exiting")
             sys.exit(0)
         # Remove the existing directory
-        shutil.rmtree(output)
+        shutil.rmtree(output_dir)
 
     writer = rosbag2_py.SequentialWriter()
     writer.open(
-        rosbag2_py.StorageOptions(uri=str(output), storage_id="mcap"),
+        rosbag2_py.StorageOptions(uri=str(output_dir), storage_id="mcap"),
         rosbag2_py.ConverterOptions(
             input_serialization_format="cdr",
             output_serialization_format="cdr",

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,85 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
+    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
+    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
+    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
+    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
+    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
+    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
+    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
+    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
+    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
+    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
+    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
+    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
+    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
+    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -714,6 +793,56 @@ files = [
 ]
 
 [[package]]
+name = "lz4"
+version = "4.3.3"
+description = "LZ4 Bindings for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "lz4-4.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b891880c187e96339474af2a3b2bfb11a8e4732ff5034be919aa9029484cd201"},
+    {file = "lz4-4.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:222a7e35137d7539c9c33bb53fcbb26510c5748779364014235afc62b0ec797f"},
+    {file = "lz4-4.3.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f76176492ff082657ada0d0f10c794b6da5800249ef1692b35cf49b1e93e8ef7"},
+    {file = "lz4-4.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1d18718f9d78182c6b60f568c9a9cec8a7204d7cb6fad4e511a2ef279e4cb05"},
+    {file = "lz4-4.3.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6cdc60e21ec70266947a48839b437d46025076eb4b12c76bd47f8e5eb8a75dcc"},
+    {file = "lz4-4.3.3-cp310-cp310-win32.whl", hash = "sha256:c81703b12475da73a5d66618856d04b1307e43428a7e59d98cfe5a5d608a74c6"},
+    {file = "lz4-4.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:43cf03059c0f941b772c8aeb42a0813d68d7081c009542301637e5782f8a33e2"},
+    {file = "lz4-4.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:30e8c20b8857adef7be045c65f47ab1e2c4fabba86a9fa9a997d7674a31ea6b6"},
+    {file = "lz4-4.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2f7b1839f795315e480fb87d9bc60b186a98e3e5d17203c6e757611ef7dcef61"},
+    {file = "lz4-4.3.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edfd858985c23523f4e5a7526ca6ee65ff930207a7ec8a8f57a01eae506aaee7"},
+    {file = "lz4-4.3.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e9c410b11a31dbdc94c05ac3c480cb4b222460faf9231f12538d0074e56c563"},
+    {file = "lz4-4.3.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2507ee9c99dbddd191c86f0e0c8b724c76d26b0602db9ea23232304382e1f21"},
+    {file = "lz4-4.3.3-cp311-cp311-win32.whl", hash = "sha256:f180904f33bdd1e92967923a43c22899e303906d19b2cf8bb547db6653ea6e7d"},
+    {file = "lz4-4.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:b14d948e6dce389f9a7afc666d60dd1e35fa2138a8ec5306d30cd2e30d36b40c"},
+    {file = "lz4-4.3.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e36cd7b9d4d920d3bfc2369840da506fa68258f7bb176b8743189793c055e43d"},
+    {file = "lz4-4.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:31ea4be9d0059c00b2572d700bf2c1bc82f241f2c3282034a759c9a4d6ca4dc2"},
+    {file = "lz4-4.3.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33c9a6fd20767ccaf70649982f8f3eeb0884035c150c0b818ea660152cf3c809"},
+    {file = "lz4-4.3.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bca8fccc15e3add173da91be8f34121578dc777711ffd98d399be35487c934bf"},
+    {file = "lz4-4.3.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7d84b479ddf39fe3ea05387f10b779155fc0990125f4fb35d636114e1c63a2e"},
+    {file = "lz4-4.3.3-cp312-cp312-win32.whl", hash = "sha256:337cb94488a1b060ef1685187d6ad4ba8bc61d26d631d7ba909ee984ea736be1"},
+    {file = "lz4-4.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:5d35533bf2cee56f38ced91f766cd0038b6abf46f438a80d50c52750088be93f"},
+    {file = "lz4-4.3.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:363ab65bf31338eb364062a15f302fc0fab0a49426051429866d71c793c23394"},
+    {file = "lz4-4.3.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a136e44a16fc98b1abc404fbabf7f1fada2bdab6a7e970974fb81cf55b636d0"},
+    {file = "lz4-4.3.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abc197e4aca8b63f5ae200af03eb95fb4b5055a8f990079b5bdf042f568469dd"},
+    {file = "lz4-4.3.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56f4fe9c6327adb97406f27a66420b22ce02d71a5c365c48d6b656b4aaeb7775"},
+    {file = "lz4-4.3.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f0e822cd7644995d9ba248cb4b67859701748a93e2ab7fc9bc18c599a52e4604"},
+    {file = "lz4-4.3.3-cp38-cp38-win32.whl", hash = "sha256:24b3206de56b7a537eda3a8123c644a2b7bf111f0af53bc14bed90ce5562d1aa"},
+    {file = "lz4-4.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:b47839b53956e2737229d70714f1d75f33e8ac26e52c267f0197b3189ca6de24"},
+    {file = "lz4-4.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6756212507405f270b66b3ff7f564618de0606395c0fe10a7ae2ffcbbe0b1fba"},
+    {file = "lz4-4.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee9ff50557a942d187ec85462bb0960207e7ec5b19b3b48949263993771c6205"},
+    {file = "lz4-4.3.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b901c7784caac9a1ded4555258207d9e9697e746cc8532129f150ffe1f6ba0d"},
+    {file = "lz4-4.3.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6d9ec061b9eca86e4dcc003d93334b95d53909afd5a32c6e4f222157b50c071"},
+    {file = "lz4-4.3.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4c7bf687303ca47d69f9f0133274958fd672efaa33fb5bcde467862d6c621f0"},
+    {file = "lz4-4.3.3-cp39-cp39-win32.whl", hash = "sha256:054b4631a355606e99a42396f5db4d22046a3397ffc3269a348ec41eaebd69d2"},
+    {file = "lz4-4.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:eac9af361e0d98335a02ff12fb56caeb7ea1196cf1a49dbf6f17828a131da807"},
+    {file = "lz4-4.3.3.tar.gz", hash = "sha256:01fe674ef2889dbb9899d8a67361e0c4a2c833af5aeb37dd505727cf5d2a131e"},
+]
+
+[package.extras]
+docs = ["sphinx (>=1.6.0)", "sphinx-bootstrap-theme"]
+flake8 = ["flake8"]
+tests = ["psutil", "pytest (!=3.3.0)", "pytest-cov"]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -869,6 +998,21 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1)", "numpy (>=1.25)", "pybind11 (>=2.6)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+
+[[package]]
+name = "mcap"
+version = "1.2.1"
+description = "MCAP libraries for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mcap-1.2.1-py3-none-any.whl", hash = "sha256:e55804906e4a60cef90840e5755fa1002420ec59bddb7ea01cdc7e15d5331cdf"},
+    {file = "mcap-1.2.1.tar.gz", hash = "sha256:b7b8223da9235aa2543bf363c3451fd53e163c6539c5cf46cea32aa1b4c78b79"},
+]
+
+[package.dependencies]
+lz4 = "*"
+zstandard = "*"
 
 [[package]]
 name = "mdurl"
@@ -1333,6 +1477,17 @@ mic = ["olefile"]
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 typing = ["typing-extensions"]
 xmp = ["defusedxml"]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
 
 [[package]]
 name = "pygments"
@@ -2113,7 +2268,119 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[[package]]
+name = "zstandard"
+version = "0.23.0"
+description = "Zstandard bindings for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zstandard-0.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf0a05b6059c0528477fba9054d09179beb63744355cab9f38059548fedd46a9"},
+    {file = "zstandard-0.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc9ca1c9718cb3b06634c7c8dec57d24e9438b2aa9a0f02b8bb36bf478538880"},
+    {file = "zstandard-0.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77da4c6bfa20dd5ea25cbf12c76f181a8e8cd7ea231c673828d0386b1740b8dc"},
+    {file = "zstandard-0.23.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2170c7e0367dde86a2647ed5b6f57394ea7f53545746104c6b09fc1f4223573"},
+    {file = "zstandard-0.23.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c16842b846a8d2a145223f520b7e18b57c8f476924bda92aeee3a88d11cfc391"},
+    {file = "zstandard-0.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:157e89ceb4054029a289fb504c98c6a9fe8010f1680de0201b3eb5dc20aa6d9e"},
+    {file = "zstandard-0.23.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:203d236f4c94cd8379d1ea61db2fce20730b4c38d7f1c34506a31b34edc87bdd"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:dc5d1a49d3f8262be192589a4b72f0d03b72dcf46c51ad5852a4fdc67be7b9e4"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:752bf8a74412b9892f4e5b58f2f890a039f57037f52c89a740757ebd807f33ea"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:80080816b4f52a9d886e67f1f96912891074903238fe54f2de8b786f86baded2"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84433dddea68571a6d6bd4fbf8ff398236031149116a7fff6f777ff95cad3df9"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ab19a2d91963ed9e42b4e8d77cd847ae8381576585bad79dbd0a8837a9f6620a"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:59556bf80a7094d0cfb9f5e50bb2db27fefb75d5138bb16fb052b61b0e0eeeb0"},
+    {file = "zstandard-0.23.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:27d3ef2252d2e62476389ca8f9b0cf2bbafb082a3b6bfe9d90cbcbb5529ecf7c"},
+    {file = "zstandard-0.23.0-cp310-cp310-win32.whl", hash = "sha256:5d41d5e025f1e0bccae4928981e71b2334c60f580bdc8345f824e7c0a4c2a813"},
+    {file = "zstandard-0.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:519fbf169dfac1222a76ba8861ef4ac7f0530c35dd79ba5727014613f91613d4"},
+    {file = "zstandard-0.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:34895a41273ad33347b2fc70e1bff4240556de3c46c6ea430a7ed91f9042aa4e"},
+    {file = "zstandard-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:77ea385f7dd5b5676d7fd943292ffa18fbf5c72ba98f7d09fc1fb9e819b34c23"},
+    {file = "zstandard-0.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:983b6efd649723474f29ed42e1467f90a35a74793437d0bc64a5bf482bedfa0a"},
+    {file = "zstandard-0.23.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80a539906390591dd39ebb8d773771dc4db82ace6372c4d41e2d293f8e32b8db"},
+    {file = "zstandard-0.23.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:445e4cb5048b04e90ce96a79b4b63140e3f4ab5f662321975679b5f6360b90e2"},
+    {file = "zstandard-0.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd30d9c67d13d891f2360b2a120186729c111238ac63b43dbd37a5a40670b8ca"},
+    {file = "zstandard-0.23.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d20fd853fbb5807c8e84c136c278827b6167ded66c72ec6f9a14b863d809211c"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ed1708dbf4d2e3a1c5c69110ba2b4eb6678262028afd6c6fbcc5a8dac9cda68e"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:be9b5b8659dff1f913039c2feee1aca499cfbc19e98fa12bc85e037c17ec6ca5"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:65308f4b4890aa12d9b6ad9f2844b7ee42c7f7a4fd3390425b242ffc57498f48"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:98da17ce9cbf3bfe4617e836d561e433f871129e3a7ac16d6ef4c680f13a839c"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:8ed7d27cb56b3e058d3cf684d7200703bcae623e1dcc06ed1e18ecda39fee003"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:b69bb4f51daf461b15e7b3db033160937d3ff88303a7bc808c67bbc1eaf98c78"},
+    {file = "zstandard-0.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:034b88913ecc1b097f528e42b539453fa82c3557e414b3de9d5632c80439a473"},
+    {file = "zstandard-0.23.0-cp311-cp311-win32.whl", hash = "sha256:f2d4380bf5f62daabd7b751ea2339c1a21d1c9463f1feb7fc2bdcea2c29c3160"},
+    {file = "zstandard-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:62136da96a973bd2557f06ddd4e8e807f9e13cbb0bfb9cc06cfe6d98ea90dfe0"},
+    {file = "zstandard-0.23.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b4567955a6bc1b20e9c31612e615af6b53733491aeaa19a6b3b37f3b65477094"},
+    {file = "zstandard-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e172f57cd78c20f13a3415cc8dfe24bf388614324d25539146594c16d78fcc8"},
+    {file = "zstandard-0.23.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0e166f698c5a3e914947388c162be2583e0c638a4703fc6a543e23a88dea3c1"},
+    {file = "zstandard-0.23.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12a289832e520c6bd4dcaad68e944b86da3bad0d339ef7989fb7e88f92e96072"},
+    {file = "zstandard-0.23.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d50d31bfedd53a928fed6707b15a8dbeef011bb6366297cc435accc888b27c20"},
+    {file = "zstandard-0.23.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72c68dda124a1a138340fb62fa21b9bf4848437d9ca60bd35db36f2d3345f373"},
+    {file = "zstandard-0.23.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53dd9d5e3d29f95acd5de6802e909ada8d8d8cfa37a3ac64836f3bc4bc5512db"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:6a41c120c3dbc0d81a8e8adc73312d668cd34acd7725f036992b1b72d22c1772"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:40b33d93c6eddf02d2c19f5773196068d875c41ca25730e8288e9b672897c105"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9206649ec587e6b02bd124fb7799b86cddec350f6f6c14bc82a2b70183e708ba"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:76e79bc28a65f467e0409098fa2c4376931fd3207fbeb6b956c7c476d53746dd"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:66b689c107857eceabf2cf3d3fc699c3c0fe8ccd18df2219d978c0283e4c508a"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9c236e635582742fee16603042553d276cca506e824fa2e6489db04039521e90"},
+    {file = "zstandard-0.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a8fffdbd9d1408006baaf02f1068d7dd1f016c6bcb7538682622c556e7b68e35"},
+    {file = "zstandard-0.23.0-cp312-cp312-win32.whl", hash = "sha256:dc1d33abb8a0d754ea4763bad944fd965d3d95b5baef6b121c0c9013eaf1907d"},
+    {file = "zstandard-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:64585e1dba664dc67c7cdabd56c1e5685233fbb1fc1966cfba2a340ec0dfff7b"},
+    {file = "zstandard-0.23.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:576856e8594e6649aee06ddbfc738fec6a834f7c85bf7cadd1c53d4a58186ef9"},
+    {file = "zstandard-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:38302b78a850ff82656beaddeb0bb989a0322a8bbb1bf1ab10c17506681d772a"},
+    {file = "zstandard-0.23.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2240ddc86b74966c34554c49d00eaafa8200a18d3a5b6ffbf7da63b11d74ee2"},
+    {file = "zstandard-0.23.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ef230a8fd217a2015bc91b74f6b3b7d6522ba48be29ad4ea0ca3a3775bf7dd5"},
+    {file = "zstandard-0.23.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:774d45b1fac1461f48698a9d4b5fa19a69d47ece02fa469825b442263f04021f"},
+    {file = "zstandard-0.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f77fa49079891a4aab203d0b1744acc85577ed16d767b52fc089d83faf8d8ed"},
+    {file = "zstandard-0.23.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ac184f87ff521f4840e6ea0b10c0ec90c6b1dcd0bad2f1e4a9a1b4fa177982ea"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c363b53e257246a954ebc7c488304b5592b9c53fbe74d03bc1c64dda153fb847"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e7792606d606c8df5277c32ccb58f29b9b8603bf83b48639b7aedf6df4fe8171"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a0817825b900fcd43ac5d05b8b3079937073d2b1ff9cf89427590718b70dd840"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9da6bc32faac9a293ddfdcb9108d4b20416219461e4ec64dfea8383cac186690"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fd7699e8fd9969f455ef2926221e0233f81a2542921471382e77a9e2f2b57f4b"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d477ed829077cd945b01fc3115edd132c47e6540ddcd96ca169facff28173057"},
+    {file = "zstandard-0.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ce8b52c5987b3e34d5674b0ab529a4602b632ebab0a93b07bfb4dfc8f8a33"},
+    {file = "zstandard-0.23.0-cp313-cp313-win32.whl", hash = "sha256:a9b07268d0c3ca5c170a385a0ab9fb7fdd9f5fd866be004c4ea39e44edce47dd"},
+    {file = "zstandard-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:f3513916e8c645d0610815c257cbfd3242adfd5c4cfa78be514e5a3ebb42a41b"},
+    {file = "zstandard-0.23.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2ef3775758346d9ac6214123887d25c7061c92afe1f2b354f9388e9e4d48acfc"},
+    {file = "zstandard-0.23.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4051e406288b8cdbb993798b9a45c59a4896b6ecee2f875424ec10276a895740"},
+    {file = "zstandard-0.23.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2d1a054f8f0a191004675755448d12be47fa9bebbcffa3cdf01db19f2d30a54"},
+    {file = "zstandard-0.23.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f83fa6cae3fff8e98691248c9320356971b59678a17f20656a9e59cd32cee6d8"},
+    {file = "zstandard-0.23.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:32ba3b5ccde2d581b1e6aa952c836a6291e8435d788f656fe5976445865ae045"},
+    {file = "zstandard-0.23.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f146f50723defec2975fb7e388ae3a024eb7151542d1599527ec2aa9cacb152"},
+    {file = "zstandard-0.23.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1bfe8de1da6d104f15a60d4a8a768288f66aa953bbe00d027398b93fb9680b26"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:29a2bc7c1b09b0af938b7a8343174b987ae021705acabcbae560166567f5a8db"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:61f89436cbfede4bc4e91b4397eaa3e2108ebe96d05e93d6ccc95ab5714be512"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:53ea7cdc96c6eb56e76bb06894bcfb5dfa93b7adcf59d61c6b92674e24e2dd5e"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:a4ae99c57668ca1e78597d8b06d5af837f377f340f4cce993b551b2d7731778d"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:379b378ae694ba78cef921581ebd420c938936a153ded602c4fea612b7eaa90d"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:50a80baba0285386f97ea36239855f6020ce452456605f262b2d33ac35c7770b"},
+    {file = "zstandard-0.23.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:61062387ad820c654b6a6b5f0b94484fa19515e0c5116faf29f41a6bc91ded6e"},
+    {file = "zstandard-0.23.0-cp38-cp38-win32.whl", hash = "sha256:b8c0bd73aeac689beacd4e7667d48c299f61b959475cdbb91e7d3d88d27c56b9"},
+    {file = "zstandard-0.23.0-cp38-cp38-win_amd64.whl", hash = "sha256:a05e6d6218461eb1b4771d973728f0133b2a4613a6779995df557f70794fd60f"},
+    {file = "zstandard-0.23.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3aa014d55c3af933c1315eb4bb06dd0459661cc0b15cd61077afa6489bec63bb"},
+    {file = "zstandard-0.23.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a7f0804bb3799414af278e9ad51be25edf67f78f916e08afdb983e74161b916"},
+    {file = "zstandard-0.23.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb2b1ecfef1e67897d336de3a0e3f52478182d6a47eda86cbd42504c5cbd009a"},
+    {file = "zstandard-0.23.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:837bb6764be6919963ef41235fd56a6486b132ea64afe5fafb4cb279ac44f259"},
+    {file = "zstandard-0.23.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1516c8c37d3a053b01c1c15b182f3b5f5eef19ced9b930b684a73bad121addf4"},
+    {file = "zstandard-0.23.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48ef6a43b1846f6025dde6ed9fee0c24e1149c1c25f7fb0a0585572b2f3adc58"},
+    {file = "zstandard-0.23.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11e3bf3c924853a2d5835b24f03eeba7fc9b07d8ca499e247e06ff5676461a15"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2fb4535137de7e244c230e24f9d1ec194f61721c86ebea04e1581d9d06ea1269"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8c24f21fa2af4bb9f2c492a86fe0c34e6d2c63812a839590edaf177b7398f700"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a8c86881813a78a6f4508ef9daf9d4995b8ac2d147dcb1a450448941398091c9"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:fe3b385d996ee0822fd46528d9f0443b880d4d05528fd26a9119a54ec3f91c69"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:82d17e94d735c99621bf8ebf9995f870a6b3e6d14543b99e201ae046dfe7de70"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:c7c517d74bea1a6afd39aa612fa025e6b8011982a0897768a2f7c8ab4ebb78a2"},
+    {file = "zstandard-0.23.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fd7e0f1cfb70eb2f95a19b472ee7ad6d9a0a992ec0ae53286870c104ca939e5"},
+    {file = "zstandard-0.23.0-cp39-cp39-win32.whl", hash = "sha256:43da0f0092281bf501f9c5f6f3b4c975a8a0ea82de49ba3f7100e64d422a1274"},
+    {file = "zstandard-0.23.0-cp39-cp39-win_amd64.whl", hash = "sha256:f8346bfa098532bc1fb6c7ef06783e969d87a99dd1d2a5a18a892c1d7a643c58"},
+    {file = "zstandard-0.23.0.tar.gz", hash = "sha256:b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\""}
+
+[package.extras]
+cffi = ["cffi (>=1.11)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d35cb5fd877cd200643724aa85753a44f1d05e42cf5704e199206477c9b4312f"
+content-hash = "89fa3f879a5d373923ea5f8cb58edb75997b62d02cb7736b9f9a645286edad00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ torchvision = "^0.20.1"
 tqdm = "^4.66.5"
 transforms3d = "^0.4.2"
 typed-argument-parser = "^1.10.1"
+mcap = "^1.2.1"
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
This pull request introduces several enhancements and new features across various files, focusing on dummy data generation, and MCAP file conversion. The most important changes include renaming a workflow file, adding new functions for dummy data insertion, and implementing a new script for converting recordings to MCAP format.

### Workflow and Configuration Updates:
* Renamed `.github/workflows/create_db.yml` to `.github/workflows/dummy_db.yml` and updated the workflow to include dummy data population steps. (`.github/workflows/dummy_db.yml`) [[1]](diffhunk://#diff-fab767ec0a007fe4ea43b49365f519504d716b01006ae3c343eec737f6e95f44L1-R1) [[2]](diffhunk://#diff-fab767ec0a007fe4ea43b49365f519504d716b01006ae3c343eec737f6e95f44L32-R36)

### Dummy Data Insertion:
* Added new functions in `ddlitlab2024/dataset/dummy_data.py` to insert dummy data into the database, including recordings, images, rotations, joint states, joint commands, and game states. (`ddlitlab2024/dataset/dummy_data.py`)

### MCAP File Conversion:
* Implemented a new script `recording2mcap.py` for converting recordings to MCAP format, including functions to write images, rotations, joint states, joint commands, and game states to MCAP files. (`ddlitlab2024/dataset/recording2mcap.py`)

### Miscellaneous Updates:
* Added new words to the spell checker configuration in `.vscode/settings.json`. (`.vscode/settings.json`)
* Added a new layout configuration file `lichtblick_layout.json`. (`ddlitlab2024/dataset/lichtblick_layout.json`)
* Added a new utility function `stamp_to_seconds_nanoseconds` to convert timestamps. (`ddlitlab2024/dataset/models.py`)
* Removed unused SQLite connection code from `reader.py`. (`ddlitlab2024/dataset/reader.py`)
* Added `mcap` dependency to `pyproject.toml`. (`pyproject.toml`)