### PR TITLE
ci(poetry): cache installed dependencies

### DIFF
--- a/.github/workflows/dummy_db.yml
+++ b/.github/workflows/dummy_db.yml
@@ -14,17 +14,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
-      - name: Install Poetry
-        run: |
-          curl -fsSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          cache: "poetry"
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
according to the `actions/setup-python` [docs]

[docs]: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages
