### PR TITLE
CI: fix ubuntu22.04 with python 3.10

### DIFF
--- a/.github/workflows/test_dataset.yml
+++ b/.github/workflows/test_dataset.yml
@@ -12,7 +12,11 @@ jobs:
   test_dataset:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04]
+        include:
+          - os: ubuntu-22.04
+            python-version: 3.10.x
+          - os: ubuntu-24.04
+            python-version: 3.12.x
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -25,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
           cache: "poetry"
 
       - name: Install dependencies

--- a/ddlitlab2024/dataset/resampling/resampler.py
+++ b/ddlitlab2024/dataset/resampling/resampler.py
@@ -1,11 +1,14 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Generic, TypeVar
 
 from ddlitlab2024.dataset.imports.data import InputData
 
+T = TypeVar("T")
+
 
 @dataclass
-class Sample[T]:
+class Sample(Generic[T]):
     data: T
     timestamp: float
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow to improve compatibility and specify Python versions for testing.

Changes to GitHub Actions workflow:

* [`.github/workflows/test_dataset.yml`](diffhunk://#diff-0916d765e9f9cc2ac0cdb3836b7115691504b8529e4af6f82a6a21f148644985L15-R19): Updated the `matrix` strategy to specify Python versions 3.10.x for `ubuntu-22.04` and 3.12.x for `ubuntu-24.04`.
* [`.github/workflows/test_dataset.yml`](diffhunk://#diff-0916d765e9f9cc2ac0cdb3836b7115691504b8529e4af6f82a6a21f148644985L28-R32): Modified the `Set up Python` step to use the specific Python version from the matrix.