### PR TITLE
Add import and conversion of `/imu/data`

### DIFF
--- a/ddlitlab2024/dataset/converters/game_state_converter.py
+++ b/ddlitlab2024/dataset/converters/game_state_converter.py
@@ -7,7 +7,7 @@ from ddlitlab2024.dataset.models import GameState, Recording, RobotState, TeamCo
 from ddlitlab2024.dataset.resampling.original_rate_resampler import OriginalRateResampler
 
 
-class GameStateMessage(Enum):
+class GameStateMessage(int, Enum):
     INITIAL = 0
     READY = 1
     SET = 2

--- a/ddlitlab2024/dataset/converters/synced_data_converter.py
+++ b/ddlitlab2024/dataset/converters/synced_data_converter.py
@@ -26,8 +26,7 @@ class SyncedDataConverter(Converter):
     def convert_to_model(self, data: InputData, relative_timestamp: float, recording: Recording) -> ModelData:
         assert data.joint_state is not None, "joint_states are required in synced resampling data"
         assert data.joint_command is not None, "joint_commands are required in synced resampling data"
-        # @TODO: add once tf conversion to rotation is implemented
-        # assert data.rotation is not None, "IMU rotation is required in synced resampling data"
+        assert data.rotation is not None, "IMU rotation is required in synced resampling data"
 
         models = ModelData()
 
@@ -44,10 +43,10 @@ class SyncedDataConverter(Converter):
         return Rotation(
             stamp=sampling_timestamp,
             recording=recording,
-            x=msg.orientation.x,
-            y=msg.orientation.y,
-            z=msg.orientation.z,
-            w=msg.orientation.w,
+            x=msg.x,
+            y=msg.y,
+            z=msg.z,
+            w=msg.w,
         )
 
     def _create_joint_states(self, msg, sampling_timestamp: float, recording: Recording) -> JointStates:

--- a/ddlitlab2024/dataset/imports/data.py
+++ b/ddlitlab2024/dataset/imports/data.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from ddlitlab2024.dataset.models import GameState, Image, JointCommands, JointStates, Recording
+from ddlitlab2024.dataset.models import GameState, Image, JointCommands, JointStates, Recording, Rotation
 
 
 @dataclass
@@ -19,6 +19,7 @@ class InputData:
     game_state: Any = None
     joint_state: Any = None
     joint_command: Any = None
+    rotation: Any = None
 
 
 @dataclass
@@ -28,6 +29,7 @@ class ModelData:
     joint_states: list[JointStates] = field(default_factory=list)
     joint_commands: list[JointCommands] = field(default_factory=list)
     images: list[Image] = field(default_factory=list)
+    rotations: list[Rotation] = field(default_factory=list)
 
     def model_instances(self):
         return [self.recording] + self.game_states + self.joint_states + self.joint_commands + self.images

--- a/ddlitlab2024/dataset/imports/strategies/bitbots.py
+++ b/ddlitlab2024/dataset/imports/strategies/bitbots.py
@@ -77,8 +77,8 @@ class BitBotsImportStrategy(ImportStrategy):
                         last_messages_by_topic.joint_command = ros_msg
                         converter = self.synced_data_converter
                     case "/imu/data":
-                        # @TODO: implement imu conversion
-                        pass
+                        last_messages_by_topic.rotation = ros_msg
+                        converter = self.synced_data_converter
                     case "/tf":
                         # @TODO: implement imu data extraction from tf messages
                         pass
@@ -111,12 +111,13 @@ class BitBotsImportStrategy(ImportStrategy):
 
         converter.populate_recording_metadata(data, self.model_data.recording)
         model_data = converter.convert_to_model(data, relative_timestamp, self.model_data.recording)
-        if model_data:
-            self.model_data = self.model_data.merge(model_data)
+        self.model_data = self.model_data.merge(model_data)
 
         return self.model_data
 
     def _is_all_synced_data_available(self, data: InputData) -> bool:
+        # @TODO: add check for IMU data, when tf conversion to rotation is implemented
+        # return data.joint_command is not None and data.joint_state is not None and data.rotation is not None
         return data.joint_command is not None and data.joint_state is not None
 
     def _create_recording(self, summary: Summary, mcap_file_path: Path) -> Recording:

--- a/ddlitlab2024/dataset/imports/strategies/bitbots.py
+++ b/ddlitlab2024/dataset/imports/strategies/bitbots.py
@@ -126,9 +126,7 @@ class BitBotsImportStrategy(ImportStrategy):
         return self.model_data
 
     def _is_all_synced_data_available(self, data: InputData) -> bool:
-        # @TODO: add check for IMU data, when tf conversion to rotation is implemented
-        # return data.joint_command is not None and data.joint_state is not None and data.rotation is not None
-        return data.joint_command is not None and data.joint_state is not None
+        return data.joint_command is not None and data.joint_state is not None and data.rotation is not None
 
     def _create_recording(self, summary: Summary, mcap_file_path: Path) -> Recording:
         start_timestamp, end_timestamp = self._extract_timeframe(summary)


### PR DESCRIPTION
## Proposed changes

This PR adds the basic import of the `/imu/data` orientation quaternion data from rosbags.
I tested this with a converted rosbag from 2022 when we still recorded the topic.

For proper testing, we need to record a new rosbag in simulation with the current software.
Additionally for full implementation of the whole rosbag import conversion of `/tf` 
to `Rotation` to fix the missing orientation data in previous rosbags is needed.
