### PR TITLE
Extract imu data from TF

### DIFF
--- a/ddlitlab2024/dataset/converters/game_state_converter.py
+++ b/ddlitlab2024/dataset/converters/game_state_converter.py
@@ -7,7 +7,7 @@ from ddlitlab2024.dataset.models import GameState, Recording, RobotState, TeamCo
 from ddlitlab2024.dataset.resampling.original_rate_resampler import OriginalRateResampler
 
 
-class GameStateMessage(Enum):
+class GameStateMessage(int, Enum):
     INITIAL = 0
     READY = 1
     SET = 2

--- a/ddlitlab2024/dataset/converters/synced_data_converter.py
+++ b/ddlitlab2024/dataset/converters/synced_data_converter.py
@@ -26,8 +26,7 @@ class SyncedDataConverter(Converter):
     def convert_to_model(self, data: InputData, relative_timestamp: float, recording: Recording) -> ModelData:
         assert data.joint_state is not None, "joint_states are required in synced resampling data"
         assert data.joint_command is not None, "joint_commands are required in synced resampling data"
-        # @TODO: add once tf conversion to rotation is implemented
-        # assert data.rotation is not None, "IMU rotation is required in synced resampling data"
+        assert data.rotation is not None, "IMU rotation is required in synced resampling data"
 
         models = ModelData()
 
@@ -44,10 +43,10 @@ class SyncedDataConverter(Converter):
         return Rotation(
             stamp=sampling_timestamp,
             recording=recording,
-            x=msg.orientation.x,
-            y=msg.orientation.y,
-            z=msg.orientation.z,
-            w=msg.orientation.w,
+            x=msg.x,
+            y=msg.y,
+            z=msg.z,
+            w=msg.w,
         )
 
     def _create_joint_states(self, msg, sampling_timestamp: float, recording: Recording) -> JointStates:

--- a/ddlitlab2024/dataset/imports/strategies/bitbots.py
+++ b/ddlitlab2024/dataset/imports/strategies/bitbots.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
+import transforms3d as t3d
 from mcap.reader import make_reader
 from mcap.summary import Summary
 from mcap_ros2.decoder import DecoderFactory
@@ -87,8 +88,18 @@ class BitBotsImportStrategy(ImportStrategy):
                         if not has_imu_data:
                             for tf_msg in ros_msg.transforms:
                                 if tf_msg.child_frame_id == "base_footprint" and tf_msg.header.frame_id == "odom":
+                                    rot = tf_msg.transform.rotation
+
+                                    # Drop the yaw component of the quaternion
+                                    # This is necessary because the IMU data does not contain yaw information
+                                    # and the yaw in the rotation is from the odometry
+                                    # We need to drop it to avoid inconsistencies
+                                    euler = t3d.euler.quat2euler([rot.x, rot.y, rot.z, rot.w], axes="sxyz")
+                                    last_messages_by_topic.rotation = t3d.euler.euler2quat(
+                                        euler[0], euler[1], 0, axes="sxyz"
+                                    )
+                                    # TODO check the math in webots
                                     # TODO check if we need the inverse
-                                    last_messages_by_topic.rotation = tf_msg.transform.rotation
                                     converter = self.synced_data_converter
                     case _:
                         logger.warning(f"Unhandled topic: {channel.topic} without conversion. Skipping...")

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -4,14 +4,15 @@ import sys
 from pathlib import Path
 
 from sqlalchemy.orm import Session
+from transforms3d.euler import quat2euler
 
 from ddlitlab2024.dataset import logger
-from ddlitlab2024.dataset.models import JointStates, Recording, stamp_to_nanoseconds, stamp_to_seconds_nanoseconds
+from ddlitlab2024.dataset.models import Recording, stamp_to_nanoseconds, stamp_to_seconds_nanoseconds
 
 try:
     import rosbag2_py
     from builtin_interfaces.msg import Time
-    from geometry_msgs.msg import Quaternion
+    from geometry_msgs.msg import Quaternion, Vector3
     from rclpy.serialization import serialize_message
     from sensor_msgs.msg import Image, JointState
     from std_msgs.msg import Header, String
@@ -148,9 +149,12 @@ def write_rotations(
     param recording: The recording
     param writer: The mcap writer
     """
-    # Create topic
+    # Create topics
     writer.create_topic(
         rosbag2_py.TopicMetadata(name="/rotation", type="geometry_msgs/msg/Quaternion", serialization_format="cdr")
+    )
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(name="/rotation/euler", type="geometry_msgs/msg/Vector3", serialization_format="cdr")
     )
 
     # Write rotations
@@ -163,6 +167,15 @@ def write_rotations(
             w=rotation.w,
         )
         writer.write("/rotation", serialize_message(rotation_msg), stamp_to_nanoseconds(rotation.stamp))
+
+        # Convert quaternion to euler angles
+        ax, ay, az = quat2euler([rotation.w, rotation.x, rotation.y, rotation.z], axes="sxyz")
+        euler = Vector3(
+            x=ax,
+            y=ay,
+            z=az,
+        )
+        writer.write("/rotation/euler", serialize_message(euler), stamp_to_nanoseconds(rotation.stamp))
 
 
 def write_joint_states(

--- a/ddlitlab2024/dataset/recording2mcap.py
+++ b/ddlitlab2024/dataset/recording2mcap.py
@@ -255,7 +255,7 @@ def write_joint_commands(
             ("head_pan", joint_command.head_pan),
             ("head_tilt", joint_command.head_tilt),
         ]
-        joint_command_msg = JointStates(
+        joint_command_msg = JointState(
             header=Header(stamp=Time(sec=seconds, nanosec=nanoseconds), frame_id="base_link"),
             name=[name for name, _ in joints],
             position=[position for _, position in joints],


### PR DESCRIPTION
## Proposed changes
I load the quaternion rotating the base_footprint relative to the odom frame. But we need to remove the yaw component of the odometry so we only get roll and pitch. 

Rotations are kinda magic in 3D so I am not 100% sure this is correct. Needs some testing in webots etc.

## Related issues

## Checklist

- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [ ] This PR is on our `Software` project board
