### PR TITLE
feat(viz): improve display of joint data

### DIFF
--- a/ddlitlab2024/dataset/lichtblick_layout.json
+++ b/ddlitlab2024/dataset/lichtblick_layout.json
@@ -105,7 +105,9 @@
         "poseEstimateYDeviation": 0.5,
         "poseEstimateThetaDeviation": 0.26179939
       },
-      "imageMode": {}
+      "imageMode": {
+        "imageTopic": "/image"
+      }
     },
     "RawMessages!os6rgs": {
       "diffEnabled": false,
@@ -135,18 +137,50 @@
       "diffMethod": "custom",
       "diffTopicPath": "",
       "showFullMessageForDiff": false,
-      "topicPath": "/joint_states"
+      "topicPath": "/extracted/joint_states.data",
+      "expansion": {
+        "0": "e",
+        "1": "e",
+        "2": "e",
+        "3": "e",
+        "4": "e",
+        "5": "e",
+        "6": "e",
+        "7": "e",
+        "8": "e",
+        "9": "e",
+        "10": "e",
+        "11": "e",
+        "12": "e",
+        "13": "e",
+        "14": "e",
+        "15": "e",
+        "16": "e",
+        "17": "e",
+        "18": "e",
+        "19": "e"
+      }
     },
     "RawMessages!16fkjz7": {
       "diffEnabled": false,
       "diffMethod": "custom",
       "diffTopicPath": "",
       "showFullMessageForDiff": false,
-      "topicPath": "/joint_commands"
+      "topicPath": "/extracted/joint_commands.data",
+      "expansion": "all"
     }
   },
   "globalVariables": {},
-  "userNodes": {},
+  "userNodes": {
+    "9a9d2e15-0cdc-4dea-96b4-7fee14e89106": {
+      "sourceCode": "// The ./types module provides helper types for your Input events and messages.\nimport { Input, Message } from \"./types\";\n\n// Your script can output well-known message types, any of your custom message types, or\n// complete custom message types.\n//\n// Use `Message` to access types from the schemas defined in your data source:\n// type Twist = Message<\"geometry_msgs/Twist\">;\n//\n// Import from the @foxglove/schemas package to use foxglove schema types:\n// import { Pose, LocationFix } from \"@foxglove/schemas\";\n//\n// Conventionally, it's common to make a _type alias_ for your script's output type\n// and use that type name as the return type for your script function.\n// Here we've called the type `Output` but you can pick any type name.\ntype Output = { data: { name: string, position: number }[] }\n\n// These are the topics your script \"subscribes\" to. Studio will invoke your script function\n// when any message is received on one of these topics.\nexport const inputs = [\"/joint_states\"];\n\n// Any output your script produces is \"published\" to this topic. Published messages are only visible within Studio, not to your original data source.\nexport const output = \"/extracted/joint_states\"\n\n// This function is called with messages from your input topics.\n// The first argument is an event with the topic, receive time, and message.\n// Use the `Input<...>` helper to get the correct event type for your input topic messages.\nexport default function script(event: Input<\"/joint_states\">): Output {\n  const msg: Output = { data: [] }\n\n  event.message.name.forEach((name, idx) => \n    msg.data.push({\n      name,\n      position: event.message.position[idx]\n    })\n  )\n\n  return msg\n}",
+      "name": "extract_joint_states"
+    },
+    "5156c5ae-acd4-4b24-9933-ef8a2b3489c7": {
+      "sourceCode": "// The ./types module provides helper types for your Input events and messages.\nimport { Input, Message } from \"./types\";\n\n// Your script can output well-known message types, any of your custom message types, or\n// complete custom message types.\n//\n// Use `Message` to access types from the schemas defined in your data source:\n// type Twist = Message<\"geometry_msgs/Twist\">;\n//\n// Import from the @foxglove/schemas package to use foxglove schema types:\n// import { Pose, LocationFix } from \"@foxglove/schemas\";\n//\n// Conventionally, it's common to make a _type alias_ for your script's output type\n// and use that type name as the return type for your script function.\n// Here we've called the type `Output` but you can pick any type name.\ntype Output = { data: { name: string, position: number }[] }\n\n// These are the topics your script \"subscribes\" to. Studio will invoke your script function\n// when any message is received on one of these topics.\nexport const inputs = [\"/joint_commands\"];\n\n// Any output your script produces is \"published\" to this topic. Published messages are only visible within Studio, not to your original data source.\nexport const output = \"/extracted/joint_commands\"\n\n// This function is called with messages from your input topics.\n// The first argument is an event with the topic, receive time, and message.\n// Use the `Input<...>` helper to get the correct event type for your input topic messages.\nexport default function script(event: Input<\"/joint_commands\">): Output {\n  const msg: Output = { data: [] }\n\n  event.message.name.forEach((name, idx) => \n    msg.data.push({\n      name,\n      position: event.message.position[idx]\n    })\n  )\n\n  return msg\n}",
+      "name": "extract_joint_commands"
+    }
+  },
   "playbackConfig": {
     "speed": 1
   },


### PR DESCRIPTION
by lichtblick typscript user scripts

## Proposed changes
Adds two new user nodes, which extract `/joint_states` and `joint_commands` names/positions,
and combine them into a structure of `{ name, position }[]` under `/extracted/{joint_states, joint_commands}`.
