### PR TITLE
fix(import): when not all joints receive commands

### DIFF
--- a/ddlitlab2024/dataset/converters/synced_data_converter.py
+++ b/ddlitlab2024/dataset/converters/synced_data_converter.py
@@ -13,7 +13,7 @@ class SyncedDataConverter(Converter):
 
     def convert_to_model(self, data: InputData, relative_timestamp: float, recording: Recording) -> ModelData:
         assert data.joint_state is not None, "joint_states are required in synced resampling data"
-        assert all(
+        assert any(
             command is not None for command in data.joint_command.values()
         ), "joint_commands are required in synced resampling data"
         assert data.rotation is not None, "IMU rotation is required in synced resampling data"

--- a/ddlitlab2024/dataset/imports/strategies/bitbots.py
+++ b/ddlitlab2024/dataset/imports/strategies/bitbots.py
@@ -132,8 +132,8 @@ class BitBotsImportStrategy(ImportStrategy):
         return self.model_data
 
     def _is_all_synced_data_available(self, data: InputData) -> bool:
-        commands_for_all_joints_available = all(command is not None for command in data.joint_command.values())
-        return commands_for_all_joints_available and data.joint_state is not None and data.rotation is not None
+        is_any_joint_command_available = any(command is not None for command in data.joint_command.values())
+        return is_any_joint_command_available and data.joint_state is not None and data.rotation is not None
 
     def _create_recording(self, summary: Summary, mcap_file_path: Path) -> Recording:
         start_timestamp, end_timestamp = self._extract_timeframe(summary)


### PR DESCRIPTION
which can happen if we have a trimmed ROSBag, which does not contain an intial movement to walkready, as we start directly in a game and never use the arms/shoulders because we do not fall down.

Additionally, this means, that previous imports of trimmed ROSBags (GO only) have incorectly started at times, when the robot fell down the first time and the arms/shoulders were used.